### PR TITLE
feat: Implement table sorting, date formatting, and website filter

### DIFF
--- a/assets/css/admin-styles.css
+++ b/assets/css/admin-styles.css
@@ -55,3 +55,58 @@
     color: red;
     margin-top: 10px;
 }
+
+/* Table Header Styling */
+.wp-list-table th.manage-column {
+    font-weight: bold;
+}
+
+/* Sorting Arrows Styling */
+.wp-list-table th.sortable a .dashicons { /* Hide by default */
+    display: none;
+}
+
+.wp-list-table th.sorted .dashicons,
+.wp-list-table th.sortable a:focus .dashicons { /* Keep visible on focus, though WP handles this with .sorted */
+    display: inline-block;
+}
+
+/* Specific icons for active sort direction */
+.wp-list-table th.sorted.asc .dashicons-arrow-up,
+.wp-list-table th.sorted.desc .dashicons-arrow-down {
+    display: inline-block;
+}
+
+/* Lighter arrows for hover/potential sort direction (often handled by WP itself by swapping classes) */
+/* These might show the OTHER direction arrow lightly if WP adds both and hides one */
+.wp-list-table th.sortable.asc .dashicons-arrow-up-alt2,
+.wp-list-table th.sortable.desc .dashicons-arrow-down-alt2 {
+     display: inline-block;
+     color: #aaa; /* Lighter color */
+}
+
+/* Alternative: If WordPress uses ::after for sorting indicators on th.sorted */
+.wp-list-table thead th.sorted.asc::after {
+    content: "\25B2"; /* Up arrow Unicode */
+    padding-left: 5px;
+    font-size: smaller; /* Adjust size if needed */
+}
+.wp-list-table thead th.sorted.desc::after {
+    content: "\25BC"; /* Down arrow Unicode */
+    padding-left: 5px;
+    font-size: smaller; /* Adjust size if needed */
+}
+
+/* Ensure sorting indicators within links are visible - WP default */
+.wp-list-table .manage-column.sorted a .sorting-indicator,
+.wp-list-table .manage-column.sortable a .sorting-indicator {
+    visibility: visible;
+}
+
+/* Hide the one that is not active if both up/down are present in markup */
+.wp-list-table .manage-column.sorted.asc .dashicons-arrow-down,
+.wp-list-table .manage-column.sorted.desc .dashicons-arrow-up,
+.wp-list-table .manage-column.sortable.asc .dashicons-arrow-down-alt2, /* if using alt2 for inactive */
+.wp-list-table .manage-column.sortable.desc .dashicons-arrow-up-alt2 {  /* if using alt2 for inactive */
+    display: none;
+}

--- a/includes/class-bol-affiliate-insights-settings.php
+++ b/includes/class-bol-affiliate-insights-settings.php
@@ -42,6 +42,8 @@ if ( ! class_exists( 'Bol_Affiliate_Insights_Settings' ) ) {
             add_action( 'wp_ajax_bol_test_connection', array( $this, 'handle_test_connection_ajax' ) );
             // Register AJAX handler for fetching chart data for the dashboard.
             add_action( 'wp_ajax_bol_fetch_chart_data', array( $this, 'handle_fetch_chart_data_ajax' ) );
+            // AJAX handler for fetching available sites for settings page
+            add_action( 'wp_ajax_bol_fetch_available_sites', array( $this, 'handle_fetch_available_sites_ajax' ) );
             // Enqueue scripts and styles specific to the plugin's admin page.
             add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
         }
@@ -61,7 +63,10 @@ if ( ! class_exists( 'Bol_Affiliate_Insights_Settings' ) ) {
             // Get parameters from AJAX request.
             $metric = isset( $_POST['metric'] ) ? sanitize_key( $_POST['metric'] ) : 'orders';
             $period = isset( $_POST['period'] ) ? sanitize_key( $_POST['period'] ) : 'last_4_weeks';
-            // $site = isset( $_POST['site'] ) ? sanitize_key( $_POST['site'] ) : 'all_sites'; // Site selector not fully used yet
+            $chart_specific_site_filter = isset( $_POST['site'] ) ? sanitize_key( $_POST['site'] ) : 'all_sites'; // Site selector from chart controls
+
+            // Get global site filter
+            $global_selected_site = get_option('bol_affiliate_insights_selected_website', 'all_sites');
 
             // Initialize data structure for chart
             $chart_data = array(
@@ -98,26 +103,84 @@ if ( ! class_exists( 'Bol_Affiliate_Insights_Settings' ) ) {
                 return;
             }
 
-            // Example: For 'last_4_weeks', generate 4 weekly labels
+            // Determine effective site filter: global takes precedence
+            $effective_site_filter = $global_selected_site !== 'all_sites' ? $global_selected_site : $chart_specific_site_filter;
+
+            // Placeholder: Fetch actual data based on $metric, $period, and $effective_site_filter
+            // This part would involve calls to $api_client->get_promotion_methods_report() or similar,
+            // and then potentially client-side filtering if $effective_site_filter is not 'all_sites'.
+
+            // Example: (Simplified - actual data fetching based on metric and period needed)
+            $report_data_items = array(); // This should be populated by API calls based on $metric & $period
+
+            // SIMULATED DATA FETCHING AND FILTERING
+            // In a real scenario, you'd fetch data for the given $period and $metric.
+            // For example, if metric is 'orders', you might fetch promotion_methods_report
+            // to get order counts, or orders_report if it's more direct.
+            // Let's simulate fetching some generic items that include 'siteCode'
+            $simulated_api_response_items = array();
             if ($period === 'last_4_weeks') {
-                for ($i = 3; $i >= 0; $i--) { // Week -3, Week -2, Week -1, Week 0 (current week or last week)
-                    $chart_data['labels'][] = 'Week ' . (date('W') - $i); // Example: "Week 35"
-                    // Fetch data for each week (this is the complex part not fully implemented here)
-                    // For now, random data:
-                    $chart_data['datasets'][0]['data'][] = rand(10, 100); 
+                for ($i = 3; $i >= 0; $i--) {
+                    $chart_data['labels'][] = 'Week ' . (date('W') - $i);
+                    // Simulate items having a 'siteCode' and a value for the metric
+                    $simulated_api_response_items[] = array('siteCode' => 'site1', $metric => rand(10,30));
+                    $simulated_api_response_items[] = array('siteCode' => 'site2', $metric => rand(5,25));
+                    $simulated_api_response_items[] = array('siteCode' => 'site1', $metric => rand(12,35));
                 }
             } elseif ($period === 'this_month') {
-                // Generate daily labels for current month (simplified)
                 $days_in_month = (int)date('t');
                 for ($d = 1; $d <= $days_in_month; $d++) {
                     $chart_data['labels'][] = date('M') . ' ' . $d;
-                    $chart_data['datasets'][0]['data'][] = rand(5, 50); // Placeholder
+                    $simulated_api_response_items[] = array('siteCode' => 'site1', $metric => rand(2,10));
+                    $simulated_api_response_items[] = array('siteCode' => 'site2', $metric => rand(1,8));
                 }
-            } else { // Fallback for other periods - very basic
-                $chart_data['labels'] = array('Period Point 1', 'Period Point 2', 'Period Point 3');
-                $chart_data['datasets'][0]['data'] = array(rand(20,80), rand(20,80), rand(20,80));
+            } else {
+                 $chart_data['labels'] = array('Point 1', 'Point 2', 'Point 3');
+                 $simulated_api_response_items = array(
+                    array('siteCode' => 'site1', $metric => rand(20,80)),
+                    array('siteCode' => 'site2', $metric => rand(20,80)),
+                    array('siteCode' => 'site1', $metric => rand(20,80)),
+                 );
             }
-            // END *** SIMPLIFIED PLACEHOLDER DATA LOGIC FOR NOW ***
+
+            // Apply effective site filter (client-side)
+            if ($effective_site_filter !== 'all_sites' && !empty($simulated_api_response_items)) {
+                $report_data_items = array_filter($simulated_api_response_items, function ($item) use ($effective_site_filter) {
+                    return isset($item['siteCode']) && $item['siteCode'] == $effective_site_filter;
+                });
+            } else {
+                $report_data_items = $simulated_api_response_items;
+            }
+            
+            // Aggregate data for chart (this is highly simplified, actual aggregation depends on metric and labels)
+            // For this placeholder, we'll just sum up the metric for the (filtered) items for each label point.
+            // This assumes labels and data points correspond one-to-one for simplicity here.
+            foreach ($chart_data['labels'] as $index => $label) {
+                $sum_for_label = 0;
+                // This is a very naive aggregation. Real aggregation would depend on how API data maps to chart labels.
+                // For instance, if labels are weeks, you'd sum items within each week.
+                // Here, we just take a slice of items per label for simplicity.
+                $items_per_label = count($report_data_items) / count($chart_data['labels']);
+                $offset = $index * $items_per_label;
+                $items_for_this_label = array_slice($report_data_items, $offset, $items_per_label);
+
+                foreach($items_for_this_label as $item) {
+                    $sum_for_label += isset($item[$metric]) ? (float)$item[$metric] : 0;
+                }
+                $chart_data['datasets'][0]['data'][] = $sum_for_label;
+
+                // If data runs out due to filtering, fill with 0
+                if (empty($chart_data['datasets'][0]['data'][$index]) && count($report_data_items) < count($simulated_api_response_items) ) {
+                    $chart_data['datasets'][0]['data'][$index] = 0;
+                }
+            }
+            // Ensure data array has values even if all were filtered out or no data
+            if (empty($chart_data['datasets'][0]['data']) && !empty($chart_data['labels'])) {
+                $chart_data['datasets'][0]['data'] = array_fill(0, count($chart_data['labels']), 0);
+            }
+
+
+            // END *** SIMPLIFIED PLACEHOLDER DATA LOGIC WITH FILTERING ***
 
             if ($error_message) {
                 wp_send_json_error( array( 'message' => $error_message ) );
@@ -212,8 +275,32 @@ if ( ! class_exists( 'Bol_Affiliate_Insights_Settings' ) ) {
             // Localize script to pass PHP variables (like nonces) to JavaScript.
             wp_localize_script( 'bol-admin-settings-js', 'bol_settings_params', array(
                 'nonce' => wp_create_nonce( 'bol_test_connection_nonce' ), // Nonce for testing API connection.
-                'chart_nonce' => wp_create_nonce( 'bol_chart_data_nonce' ) // Nonce for fetching chart data.
+                'chart_nonce' => wp_create_nonce( 'bol_chart_data_nonce' ), // Nonce for fetching chart data.
+                'fetch_sites_nonce' => wp_create_nonce( 'bol_fetch_sites_nonce' ) // Nonce for fetching sites
             ) );
+        }
+
+        /**
+         * Handles AJAX request to fetch available sites.
+         * Used to dynamically populate the site filter dropdown on the settings page.
+         */
+        public function handle_fetch_available_sites_ajax() {
+            check_ajax_referer( 'bol_fetch_sites_nonce', 'nonce' );
+
+            $api_client = Bol_Affiliate_Insights_Plugin::get_instance()->get_api_client();
+            if ( ! $api_client ) {
+                wp_send_json_error( array( 'message' => 'API Client not available.' ) );
+                return;
+            }
+
+            $sites = $api_client->get_available_sites();
+            if ( is_wp_error( $sites ) ) {
+                wp_send_json_error( array( 'message' => 'Error fetching sites: ' . $sites->get_error_message() ) );
+            } elseif ( empty( $sites ) ) {
+                wp_send_json_success( array( 'sites' => array(), 'message' => 'No sites found or API access issue for sites.' ) );
+            } else {
+                wp_send_json_success( array( 'sites' => $sites ) );
+            }
         }
         
         /**
@@ -235,12 +322,19 @@ if ( ! class_exists( 'Bol_Affiliate_Insights_Settings' ) ) {
                 array( $this, 'sanitize_credentials' ) // Sanitization callback.
             );
 
+            // Register the setting for selected website.
+            register_setting(
+                $options_group_name, // Same group name as credentials
+                'bol_affiliate_insights_selected_website',
+                'sanitize_text_field' // Standard sanitization for a site code/ID.
+            );
+
             // Add a settings section for API credentials.
             add_settings_section(
                 'bol_api_credentials_section', // ID of the section.
                 'API Credentials',             // Title of the section.
                 array( $this, 'render_api_credentials_section_text' ), // Callback to render section description.
-                'bol-affiliate-insights'       // Page slug where this section will be displayed.
+                'bol-affiliate-insights-settings' // Page slug for this section. Changed to be more specific.
             );
 
             // Add settings field for Client ID.
@@ -248,7 +342,7 @@ if ( ! class_exists( 'Bol_Affiliate_Insights_Settings' ) ) {
                 'bol_client_id',                  // ID of the field.
                 'Client ID',                      // Title of the field.
                 array( $this, 'render_client_id_field' ), // Callback to render the field.
-                'bol-affiliate-insights',         // Page slug.
+                'bol-affiliate-insights-settings',         // Page slug.
                 'bol_api_credentials_section',    // Section ID.
                 array( 'label_for' => 'bol_client_id_field' ) // Associates label with input field.
             );
@@ -258,11 +352,72 @@ if ( ! class_exists( 'Bol_Affiliate_Insights_Settings' ) ) {
                 'bol_client_secret',              // ID of the field.
                 'Client Secret',                  // Title of the field.
                 array( $this, 'render_client_secret_field' ), // Callback to render the field.
-                'bol-affiliate-insights',         // Page slug.
+                'bol-affiliate-insights-settings',         // Page slug.
                 'bol_api_credentials_section',    // Section ID.
                 array( 'label_for' => 'bol_client_secret_field' ) // Associates label with input field.
             );
+
+            // Add a settings section for Data Filters.
+            add_settings_section(
+                'bol_data_filters_section',
+                'Data Filters',
+                array( $this, 'render_data_filters_section_text' ),
+                'bol-affiliate-insights-settings' // Same page slug
+            );
+
+            // Add settings field for Website Selector.
+            add_settings_field(
+                'bol_selected_website',
+                'Filter data by Website',
+                array( $this, 'render_selected_website_field' ),
+                'bol-affiliate-insights-settings',
+                'bol_data_filters_section',
+                array( 'label_for' => 'bol_selected_website_field' )
+            );
         }
+
+        /**
+         * Renders descriptive text for the Data Filters settings section.
+         */
+        public function render_data_filters_section_text() {
+            echo '<p>Select a website to filter the displayed report data across the plugin. This filter applies to the dashboard, report tabs, and charts.</p>';
+        }
+        
+        /**
+         * Renders the dropdown field for selecting the website to filter by.
+         */
+        public function render_selected_website_field() {
+            $current_value = get_option( 'bol_affiliate_insights_selected_website', 'all_sites' );
+            $api_client = Bol_Affiliate_Insights_Plugin::get_instance()->get_api_client();
+            $sites = array(); // Default to empty array
+
+            if ($api_client) {
+                $fetched_sites = $api_client->get_available_sites();
+                // Ensure $fetched_sites is an array and not WP_Error before using
+                if (is_array($fetched_sites)) {
+                    $sites = $fetched_sites;
+                } else {
+                     echo '<p class="notice notice-warning">Could not fetch available sites. API client might not be configured or there was an error.</p>';
+                }
+            } else {
+                echo '<p class="notice notice-warning">API Client not available. Please configure API credentials first.</p>';
+            }
+
+            echo "<select id='bol_selected_website_field' name='bol_affiliate_insights_selected_website'>";
+            echo "<option value='all_sites'" . selected( $current_value, 'all_sites', false ) . ">All Sites</option>";
+
+            if ( ! empty( $sites ) ) {
+                foreach ( $sites as $site_code => $site_name ) {
+                    echo "<option value='" . esc_attr( $site_code ) . "'" . selected( $current_value, $site_code, false ) . ">" . esc_html( $site_name ) . " (" . esc_html($site_code) . ")</option>";
+                }
+            } elseif (empty($sites) && $api_client && is_array($fetched_sites)) { // Check if $fetched_sites was an empty array from a successful call
+                 echo "<option value='' disabled>No individual sites found.</option>";
+            }
+            // If sites could not be fetched at all (e.g. API client error), the error message above is shown.
+            echo "</select>";
+            echo "<p class='description'>If 'All Sites' is selected, data from all your registered websites will be shown.</p>";
+        }
+
 
         /**
          * Renders descriptive text for the API credentials settings section.
@@ -354,6 +509,9 @@ if ( ! class_exists( 'Bol_Affiliate_Insights_Settings' ) ) {
             // Initialize API client once for all tabs, if needed.
             $plugin_instance = Bol_Affiliate_Insights_Plugin::get_instance();
             $api_client = $plugin_instance->get_api_client();
+            
+            // Get the globally selected site filter
+            $global_selected_site_filter = get_option('bol_affiliate_insights_selected_website', 'all_sites');
             ?>
             <div class="wrap">
                 <h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
@@ -416,37 +574,47 @@ if ( ! class_exists( 'Bol_Affiliate_Insights_Settings' ) ) {
                     if (!$api_client) {
                         $error_messages[] = "API Client could not be initialized. Check plugin configuration.";
                     } else {
-                    // Fetch Promotion Report Data for metrics.
-                        $promo_data = $api_client->get_promotion_methods_report( $start_date, $end_date );
-                        if ( is_wp_error( $promo_data ) ) {
-                            $error_messages[] = "Error fetching promotion data: " . esc_html( $promo_data->get_error_message() );
-                        } elseif ( isset($promo_data['items']) && !empty( $promo_data['items'] ) ) {
-                        // Aggregate clicks, orders, and revenue from promotion data.
-                            foreach ( $promo_data['items'] as $item ) {
+                        // Fetch Promotion Report Data for metrics.
+                        $promo_data_response = $api_client->get_promotion_methods_report( $start_date, $end_date ); // API call
+                        $promo_items = array();
+                        if ( is_wp_error( $promo_data_response ) ) {
+                            $error_messages[] = "Error fetching promotion data: " . esc_html( $promo_data_response->get_error_message() );
+                        } elseif ( isset($promo_data_response['items']) ) {
+                            $promo_items = $promo_data_response['items'];
+                            // Apply global site filter if set
+                            if ($global_selected_site_filter !== 'all_sites' && !empty($promo_items)) {
+                                $promo_items = array_filter($promo_items, function($item) use ($global_selected_site_filter) {
+                                    return isset($item['siteCode']) && $item['siteCode'] == $global_selected_site_filter;
+                                });
+                            }
+                            // Aggregate clicks, orders, and revenue from (filtered) promotion data.
+                            foreach ( $promo_items as $item ) {
                                 $total_clicks += isset($item['clicks']) ? (int)$item['clicks'] : 0;
                                 $total_orders += isset($item['orders']) ? (int)$item['orders'] : 0;
                                 $total_revenue += isset($item['revenueInclVat']) ? (float)$item['revenueInclVat'] : 0.0;
                             }
-                        } elseif (isset($promo_data['items']) && empty($promo_data['items'])) {
-                        // No promotion items found for this period, which is not an error.
-                        } elseif (!isset($promo_data['items']) && !is_wp_error($promo_data)) {
-                         // Response format is unexpected if 'items' key is missing and not a WP_Error.
+                        } elseif (!isset($promo_data_response['items']) && !is_wp_error($promo_data_response)) {
                              $error_messages[] = "Promotion data response is not in the expected format.";
                         }
 
-                    // Fetch Commission Report Data for metrics.
-                        $commission_data = $api_client->get_commission_revenue_report( $start_date, $end_date );
-                        if ( is_wp_error( $commission_data ) ) {
-                            $error_messages[] = "Error fetching commission data: " . esc_html( $commission_data->get_error_message() );
-                        } elseif ( isset($commission_data['items']) && !empty( $commission_data['items'] ) ) {
-                        // Aggregate commission from commission data.
-                            foreach ( $commission_data['items'] as $item ) {
+                        // Fetch Commission Report Data for metrics.
+                        $commission_data_response = $api_client->get_commission_revenue_report( $start_date, $end_date ); // API call
+                        $commission_items = array();
+                        if ( is_wp_error( $commission_data_response ) ) {
+                            $error_messages[] = "Error fetching commission data: " . esc_html( $commission_data_response->get_error_message() );
+                        } elseif ( isset($commission_data_response['items']) ) {
+                            $commission_items = $commission_data_response['items'];
+                            // Apply global site filter if set
+                            if ($global_selected_site_filter !== 'all_sites' && !empty($commission_items)) {
+                                $commission_items = array_filter($commission_items, function($item) use ($global_selected_site_filter) {
+                                    return isset($item['siteCode']) && $item['siteCode'] == $global_selected_site_filter;
+                                });
+                            }
+                            // Aggregate commission from (filtered) commission data.
+                            foreach ( $commission_items as $item ) {
                                 $total_commission += isset($item['commissionApproved']) ? (float)$item['commissionApproved'] : 0.0;
                             }
-                        } elseif (isset($commission_data['items']) && empty($commission_data['items'])) {
-                        // No commission items found for this period, not an error.
-                        } elseif (!isset($commission_data['items']) && !is_wp_error($commission_data)) {
-                        // Response format is unexpected.
+                        } elseif (!isset($commission_data_response['items']) && !is_wp_error($commission_data_response)) {
                              $error_messages[] = "Commission data response is not in the expected format.";
                         }
                     }
@@ -572,27 +740,36 @@ if ( ! class_exists( 'Bol_Affiliate_Insights_Settings' ) ) {
                             echo '<div class="notice notice-error is-dismissible"><p>API Client not available. Check plugin configuration.</p></div>';
                         } else {
                             $orders_data_response = $api_client->get_orders_report($current_start_date, $current_end_date);
+                            $order_items_to_display = array();
 
                             if (is_wp_error($orders_data_response)) {
                                 echo '<div class="notice notice-error is-dismissible"><p>Error fetching orders: ' . esc_html($orders_data_response->get_error_message()) . '</p></div>';
-                            } elseif (!isset($orders_data_response['items'])) { // Check if 'items' key exists
+                            } elseif (!isset($orders_data_response['items'])) {
                                 echo '<div class="notice notice-error is-dismissible"><p>Orders data response is not in the expected format.</p></div>';
-                            } elseif (empty($orders_data_response['items'])) {
-                                $orders_list_table = new Bol_Orders_List_Table();
-                                $orders_list_table->prepare_items( array() ); 
-                                echo '<h3>Orders Data</h3>';
-                                $orders_list_table->display();
-                                // Optional: echo '<div class="notice notice-info is-dismissible"><p>No orders found for the selected period.</p></div>';
                             } else {
-                                // We have items, prepare and display the table
+                                $order_items_to_display = $orders_data_response['items'];
+                                // Apply global site filter if set
+                                if ($global_selected_site_filter !== 'all_sites' && !empty($order_items_to_display)) {
+                                    $order_items_to_display = array_filter($order_items_to_display, function($item) use ($global_selected_site_filter) {
+                                        // Assuming 'siteCode' is present in order items; this needs verification
+                                        // If not present, orders report might not be filterable this way client-side
+                                        return isset($item['siteCode']) && $item['siteCode'] == $global_selected_site_filter;
+                                    });
+                                }
+                                
                                 $orders_list_table = new Bol_Orders_List_Table();
-                                $orders_list_table->prepare_items( $orders_data_response['items'] );
-                                
+                                $orders_list_table->prepare_items( $order_items_to_display );
                                 echo '<h3>Orders Data</h3>';
-                                // Optional: Display a count of items
-                                // echo '<p>' . sprintf( _n( '%s order found.', '%s orders found.', count($orders_data_response['items']), 'bol-affiliate-insights' ), count($orders_data_response['items']) ) . '</p>';
-                                
+                                if ($global_selected_site_filter !== 'all_sites') {
+                                    $site_name = $global_selected_site_filter; // Ideally fetch site name for display
+                                    echo '<p><em>Displaying data filtered for site: ' . esc_html($site_name) . '</em></p>';
+                                }
                                 $orders_list_table->display();
+                                if (empty($order_items_to_display) && !empty($orders_data_response['items'])) {
+                                     echo '<div class="notice notice-info is-dismissible"><p>No orders found for the selected site and period.</p></div>';
+                                } elseif (empty($order_items_to_display)) {
+                                     echo '<div class="notice notice-info is-dismissible"><p>No orders found for the selected period.</p></div>';
+                                }
                             }
                         }
                         ?>
@@ -631,22 +808,35 @@ if ( ! class_exists( 'Bol_Affiliate_Insights_Settings' ) ) {
                         if (!$api_client) {
                             echo '<div class="notice notice-error is-dismissible"><p>API Client not available. Check plugin configuration.</p></div>';
                         } else {
-                            $report_data = $api_client->get_commission_revenue_report($current_start_date, $current_end_date);
+                            $report_data_response = $api_client->get_commission_revenue_report($current_start_date, $current_end_date);
+                            $cr_items_to_display = array();
 
-                            if (is_wp_error($report_data)) {
-                                echo '<div class="notice notice-error is-dismissible"><p>Error fetching report: ' . esc_html($report_data->get_error_message()) . '</p></div>';
-                            } elseif (!isset($report_data['items'])) { // Check if 'items' key exists before checking if empty
+                            if (is_wp_error($report_data_response)) {
+                                echo '<div class="notice notice-error is-dismissible"><p>Error fetching report: ' . esc_html($report_data_response->get_error_message()) . '</p></div>';
+                            } elseif (!isset($report_data_response['items'])) {
                                 echo '<div class="notice notice-error is-dismissible"><p>Report data response is not in the expected format.</p></div>';
-                            } elseif (empty($report_data['items'])) {
+                            } else {
+                                $cr_items_to_display = $report_data_response['items'];
+                                // Apply global site filter if set
+                                if ($global_selected_site_filter !== 'all_sites' && !empty($cr_items_to_display)) {
+                                    $cr_items_to_display = array_filter($cr_items_to_display, function($item) use ($global_selected_site_filter) {
+                                        return isset($item['siteCode']) && $item['siteCode'] == $global_selected_site_filter;
+                                    });
+                                }
+
                                 $cr_list_table = new Bol_Commission_Revenue_List_Table();
-                                $cr_list_table->prepare_items( array() );
+                                $cr_list_table->prepare_items( $cr_items_to_display );
                                 echo '<h3>Commission & Revenue Data</h3>';
+                                if ($global_selected_site_filter !== 'all_sites') {
+                                    $site_name = $global_selected_site_filter; // Ideally fetch site name
+                                    echo '<p><em>Displaying data filtered for site: ' . esc_html($site_name) . '</em></p>';
+                                }
                                 $cr_list_table->display();
-                            } else { // Data found and 'items' key exists
-                                $cr_list_table = new Bol_Commission_Revenue_List_Table();
-                                $cr_list_table->prepare_items( $report_data['items'] );
-                                echo '<h3>Commission & Revenue Data</h3>';
-                                $cr_list_table->display();
+                                if (empty($cr_items_to_display) && !empty($report_data_response['items'])) {
+                                     echo '<div class="notice notice-info is-dismissible"><p>No records found for the selected site and period.</p></div>';
+                                } elseif (empty($cr_items_to_display)) {
+                                     echo '<div class="notice notice-info is-dismissible"><p>No records found for the selected period.</p></div>';
+                                }
                             }
                         }
                         ?>
@@ -685,22 +875,35 @@ if ( ! class_exists( 'Bol_Affiliate_Insights_Settings' ) ) {
                         if (!$api_client) {
                             echo '<div class="notice notice-error is-dismissible"><p>API Client not available. Check plugin configuration.</p></div>';
                         } else {
-                            $report_data = $api_client->get_promotion_methods_report($current_start_date, $current_end_date);
+                            $report_data_response = $api_client->get_promotion_methods_report($current_start_date, $current_end_date);
+                            $pm_items_to_display = array();
 
-                            if (is_wp_error($report_data)) {
-                                echo '<div class="notice notice-error is-dismissible"><p>Error fetching report: ' . esc_html($report_data->get_error_message()) . '</p></div>';
-                            } elseif (!isset($report_data['items'])) { // Check if 'items' key exists before checking if empty
+                            if (is_wp_error($report_data_response)) {
+                                echo '<div class="notice notice-error is-dismissible"><p>Error fetching report: ' . esc_html($report_data_response->get_error_message()) . '</p></div>';
+                            } elseif (!isset($report_data_response['items'])) {
                                 echo '<div class="notice notice-error is-dismissible"><p>Report data response is not in the expected format.</p></div>';
-                            } elseif (empty($report_data['items'])) {
+                            } else {
+                                $pm_items_to_display = $report_data_response['items'];
+                                // Apply global site filter if set
+                                if ($global_selected_site_filter !== 'all_sites' && !empty($pm_items_to_display)) {
+                                    $pm_items_to_display = array_filter($pm_items_to_display, function($item) use ($global_selected_site_filter) {
+                                        return isset($item['siteCode']) && $item['siteCode'] == $global_selected_site_filter;
+                                    });
+                                }
+                                
                                 $pm_list_table = new Bol_Promotion_Methods_List_Table();
-                                $pm_list_table->prepare_items( array() );
+                                $pm_list_table->prepare_items( $pm_items_to_display );
                                 echo '<h3>Promotion Methods Data</h3>';
+                                 if ($global_selected_site_filter !== 'all_sites') {
+                                    $site_name = $global_selected_site_filter; // Ideally fetch site name
+                                    echo '<p><em>Displaying data filtered for site: ' . esc_html($site_name) . '</em></p>';
+                                }
                                 $pm_list_table->display();
-                            } else { // Data found and 'items' key exists
-                                $pm_list_table = new Bol_Promotion_Methods_List_Table();
-                                $pm_list_table->prepare_items( $report_data['items'] );
-                                echo '<h3>Promotion Methods Data</h3>';
-                                $pm_list_table->display();
+                                if (empty($pm_items_to_display) && !empty($report_data_response['items'])) {
+                                     echo '<div class="notice notice-info is-dismissible"><p>No records found for the selected site and period.</p></div>';
+                                } elseif (empty($pm_items_to_display)) {
+                                     echo '<div class="notice notice-info is-dismissible"><p>No records found for the selected period.</p></div>';
+                                }
                             }
                         }
                         ?>
@@ -710,8 +913,9 @@ if ( ! class_exists( 'Bol_Affiliate_Insights_Settings' ) ) {
                     ?>
                     <form action="options.php" method="post">
                         <?php
-                        settings_fields( 'bol_affiliate_insights_options_group' );
-                        do_settings_sections( 'bol-affiliate-insights' );
+                        // Use the specific page slug for settings sections related to credentials
+                        settings_fields( 'bol_affiliate_insights_options_group' ); // This group is for all options.
+                        do_settings_sections( 'bol-affiliate-insights-settings' ); // Page slug for these sections.
                         submit_button( 'Save Settings' );
                         ?>
                     </form>

--- a/includes/class-bol-commission-revenue-list-table.php
+++ b/includes/class-bol-commission-revenue-list-table.php
@@ -77,10 +77,45 @@ if ( ! class_exists( 'Bol_Commission_Revenue_List_Table' ) ) {
          * @param array $data An array of commission/revenue data from the API.
          * @return void
          */
+        public function get_sortable_columns() {
+            $sortable_columns = array(
+                'orderDate'             => array('orderDate', false),
+                'siteName'              => array('siteName', false),
+                'frameType'             => array('frameType', false),
+                'name'                  => array('name', false),
+                'subId'                 => array('subId', false),
+                'commissionPercentage'  => array('commissionPercentage', false),
+                'commissionOriginal'    => array('commissionOriginal', false),
+                'commissionApproved'    => array('commissionApproved', false),
+                'commissionOpen'        => array('commissionOpen', false),
+                'revenueOriginalInclVat'=> array('revenueOriginalInclVat', false),
+                'revenueApprovedInclVat'=> array('revenueApprovedInclVat', false),
+                'quantityPayable'       => array('quantityPayable', false)
+            );
+            return $sortable_columns;
+        }
+
+        /**
+         * Prepares the items for display in the table.
+         *
+         * This method takes the raw data from the API, sets up column headers,
+         * and assigns the data to `$this->items`. If no data is provided,
+         * it populates `$this->items` with sample data for structural testing.
+         *
+         * @param array $data An array of commission/revenue data from the API.
+         * @return void
+         */
         public function prepare_items( $data = array() ) {
             $columns = $this->get_columns();
             $hidden = array(); // Array of hidden columns.
-            $this->_column_headers = array( $columns, $hidden, array() ); // No sortable for now
+            $sortable = $this->get_sortable_columns();
+            $this->_column_headers = array( $columns, $hidden, $sortable );
+
+            // Default sort order
+            if ( empty( $_REQUEST['orderby'] ) ) {
+                $_REQUEST['orderby'] = 'orderDate';
+                $_REQUEST['order']   = 'desc';
+            }
 
             if (empty($data)) {
                 // Updated sample data logic as above
@@ -96,6 +131,37 @@ if ( ! class_exists( 'Bol_Commission_Revenue_List_Table' ) ) {
                 }
             } else {
                 $this->items = $data;
+            }
+
+            // Sorting logic
+            $orderby = ( ! empty( $_REQUEST['orderby'] ) ) ? sanitize_text_field( $_REQUEST['orderby'] ) : 'orderDate';
+            $order   = ( ! empty( $_REQUEST['order'] ) ) ? sanitize_text_field( $_REQUEST['order'] ) : 'desc';
+
+            if ( ! empty( $orderby ) ) {
+                usort( $this->items, function( $a, $b ) use ( $orderby, $order ) {
+                    $val_a = $a[ $orderby ];
+                    $val_b = $b[ $orderby ];
+
+                    if ( in_array( $orderby, ['commissionPercentage', 'commissionOriginal', 'commissionApproved', 'commissionOpen', 'revenueOriginalInclVat', 'revenueApprovedInclVat', 'quantityPayable'] ) ) {
+                        $val_a = floatval( str_replace(',', '.', preg_replace('/[^\d,.]/', '', $val_a) ) );
+                        $val_b = floatval( str_replace(',', '.', preg_replace('/[^\d,.]/', '', $val_b) ) );
+                    } elseif ( $orderby === 'orderDate' ) {
+                        // Assuming YYYY-MM-DD format
+                        $time_a = strtotime( $val_a );
+                        $time_b = strtotime( $val_b );
+                        if ($time_a === $time_b) return 0;
+                        return ( $order === 'asc' ) ? ( $time_a < $time_b ? -1 : 1 ) : ( $time_a > $time_b ? -1 : 1 );
+                    } else {
+                        // String comparison
+                        $val_a = strtolower( (string) $val_a );
+                        $val_b = strtolower( (string) $val_b );
+                    }
+
+                    if ( $val_a == $val_b ) {
+                        return 0;
+                    }
+                    return ( $order === 'asc' ) ? ( $val_a < $val_b ? -1 : 1 ) : ( $val_a > $val_b ? -1 : 1 );
+                } );
             }
 
             // Pagination logic
@@ -125,18 +191,29 @@ if ( ! class_exists( 'Bol_Commission_Revenue_List_Table' ) ) {
         protected function column_default( $item, $column_name ) {
             switch ( $column_name ) {
                 case 'orderDate':
-                    // Assuming date format YYYY-MM-DD from API for this report, display as is.
-                    return esc_html( $item[ $column_name ] ); 
+                    // Assuming date format YYYY-MM-DD from API for this report.
+                    if ( !empty($item[ $column_name ]) && is_string($item[ $column_name ]) ) {
+                        try {
+                           $date = date_create($item[ $column_name ]);
+                           if ($date) {
+                               return esc_html( date_format($date, 'Y-m-d') );
+                           }
+                           return esc_html( $item[ $column_name ] ) . ' (Invalid Date Format)';
+                       } catch (Exception $e) {
+                           return esc_html( $item[ $column_name ] ) . ' (Error Parsing Date)';
+                       }
+                   }
+                   return 'N/A';
                 case 'commissionPercentage':
                     // Format commission percentage with one decimal place.
-                    return number_format_i18n( (float)$item[ $column_name ], 1 ) . '%';
+                    return number_format_i18n( (float) preg_replace('/[^\d,.]/', '', str_replace(',', '.', $item[ $column_name ]) ), 1 ) . '%';
                 case 'commissionOriginal':
                 case 'commissionApproved':
                 case 'commissionOpen':
                 case 'revenueOriginalInclVat':
                 case 'revenueApprovedInclVat':
                     // Format currency values.
-                    return '€' . number_format_i18n( (float)$item[ $column_name ], 2 );
+                    return '€' . number_format_i18n( (float) preg_replace('/[^\d,.]/', '', str_replace(',', '.', $item[ $column_name ]) ), 2 );
                 case 'quantityPayable':
                     // Format quantity as an integer.
                     return number_format_i18n( (int)$item[ $column_name ] );

--- a/includes/class-bol-orders-list-table.php
+++ b/includes/class-bol-orders-list-table.php
@@ -66,14 +66,19 @@ if ( ! class_exists( 'Bol_Orders_List_Table' ) ) {
         // For now, let's make a few sortable. API might not support sorting, so this would be client-side after fetching all.
         // Or, we might need to implement server-side sorting via API params if possible.
         // For this step, let's assume client-side sorting or no sorting initially to keep it simple.
-        // public function get_sortable_columns() {
-        //     $sortable_columns = array(
-        //         'orderDate'  => array('orderDate', false), //true for already sorted
-        //         'priceInclVat' => array('priceInclVat', false),
-        //         'commission' => array('commission', false)
-        //     );
-        //     return $sortable_columns;
-        // }
+        public function get_sortable_columns() {
+            $sortable_columns = array(
+                'orderDate'     => array('orderDate', false),
+                'orderId'       => array('orderId', false),
+                'orderItemId'   => array('orderItemId', false),
+                'productTitle'  => array('productTitle', false),
+                'quantity'      => array('quantity', false),
+                'priceInclVat'  => array('priceInclVat', false),
+                'commission'    => array('commission', false),
+                'status'        => array('status', false)
+            );
+            return $sortable_columns;
+        }
 
         /**
          * Prepares the items for display in the table.
@@ -89,8 +94,14 @@ if ( ! class_exists( 'Bol_Orders_List_Table' ) ) {
         public function prepare_items( $data = array() ) {
             $columns = $this->get_columns();
             $hidden = array(); // Array of hidden columns.
-            // $sortable = $this->get_sortable_columns(); // Still commented out
-            $this->_column_headers = array( $columns, $hidden, array() /*$sortable*/ );
+            $sortable = $this->get_sortable_columns();
+            $this->_column_headers = array( $columns, $hidden, $sortable );
+
+            // Default sort order
+            if ( empty( $_REQUEST['orderby'] ) ) {
+                $_REQUEST['orderby'] = 'orderDate';
+                $_REQUEST['order']   = 'desc';
+            }
             
             // Assign data to items property
             if (empty($data)) {
@@ -106,6 +117,35 @@ if ( ! class_exists( 'Bol_Orders_List_Table' ) ) {
                 }
             } else {
                 $this->items = $data;
+            }
+
+            // Sorting logic
+            $orderby = ( ! empty( $_REQUEST['orderby'] ) ) ? sanitize_text_field( $_REQUEST['orderby'] ) : 'orderDate';
+            $order   = ( ! empty( $_REQUEST['order'] ) ) ? sanitize_text_field( $_REQUEST['order'] ) : 'desc';
+
+            if ( ! empty( $orderby ) ) {
+                usort( $this->items, function( $a, $b ) use ( $orderby, $order ) {
+                    $val_a = $a[ $orderby ];
+                    $val_b = $b[ $orderby ];
+
+                    if ( in_array( $orderby, ['quantity', 'priceInclVat', 'commission'] ) ) {
+                        $val_a = floatval( str_replace(',', '.', preg_replace('/[^\d,.]/', '', $val_a) ) );
+                        $val_b = floatval( str_replace(',', '.', preg_replace('/[^\d,.]/', '', $val_b) ) );
+                    } elseif ( $orderby === 'orderDate' ) {
+                        $time_a = strtotime( $val_a );
+                        $time_b = strtotime( $val_b );
+                        if ($time_a === $time_b) return 0;
+                        return ( $order === 'asc' ) ? ( $time_a < $time_b ? -1 : 1 ) : ( $time_a > $time_b ? -1 : 1 );
+                    } else {
+                        $val_a = strtolower( (string) $val_a );
+                        $val_b = strtolower( (string) $val_b );
+                    }
+
+                    if ( $val_a == $val_b ) {
+                        return 0;
+                    }
+                    return ( $order === 'asc' ) ? ( $val_a < $val_b ? -1 : 1 ) : ( $val_a > $val_b ? -1 : 1 );
+                } );
             }
 
             // Pagination logic
@@ -140,17 +180,21 @@ if ( ! class_exists( 'Bol_Orders_List_Table' ) ) {
                     if ( !empty($item[ $column_name ]) && is_string($item[ $column_name ]) ) {
                          try {
                             // Create a DateTime object with WordPress timezone and format it.
-                            return esc_html( date_format(date_create($item[ $column_name ], wp_timezone()), 'Y-m-d H:i:s') );
+                            $date = date_create($item[ $column_name ], wp_timezone());
+                            if ($date) {
+                                return esc_html( date_format($date, 'Y-m-d') );
+                            }
+                            return esc_html( $item[ $column_name ] ) . ' (Invalid Date Format)';
                         } catch (Exception $e) {
                             // Fallback for invalid date format from API.
-                            return esc_html( $item[ $column_name ] ) . ' (Invalid Date)'; 
+                            return esc_html( $item[ $column_name ] ) . ' (Error Parsing Date)'; 
                         }
                     }
                     return 'N/A'; // Placeholder if date is missing or invalid.
                 case 'priceInclVat':
                 case 'commission':
                     // Format currency values.
-                    return '€' . number_format_i18n( (float)$item[ $column_name ], 2 );
+                    return '€' . number_format_i18n( (float) preg_replace('/[^\d,.]/', '', str_replace(',', '.', $item[ $column_name ]) ), 2 );
                 case 'quantity':
                     // Format quantity as an integer.
                     return number_format_i18n( (int)$item[ $column_name ] );

--- a/includes/class-bol-promotion-methods-list-table.php
+++ b/includes/class-bol-promotion-methods-list-table.php
@@ -77,10 +77,46 @@ if ( ! class_exists( 'Bol_Promotion_Methods_List_Table' ) ) {
          * @param array $data An array of promotion methods data from the API.
          * @return void
          */
+        public function get_sortable_columns() {
+            $sortable_columns = array(
+                'date'              => array('date', false),
+                'siteName'          => array('siteName', false),
+                'frameType'         => array('frameType', false),
+                'name'              => array('name', false),
+                'subId'             => array('subId', false),
+                'clicks'            => array('clicks', false),
+                'impressions'       => array('impressions', false),
+                'clickThroughRate'  => array('clickThroughRate', false),
+                'earningsPerClick'  => array('earningsPerClick', false),
+                'orders'            => array('orders', false),
+                'conversion'        => array('conversion', false),
+                'revenueInclVat'    => array('revenueInclVat', false),
+                'averageOrderValue' => array('averageOrderValue', false)
+            );
+            return $sortable_columns;
+        }
+
+        /**
+         * Prepares the items for display in the table.
+         *
+         * This method takes the raw data from the API, sets up column headers,
+         * and assigns the data to `$this->items`. If no data is provided,
+         * it populates `$this->items` with sample data for structural testing.
+         *
+         * @param array $data An array of promotion methods data from the API.
+         * @return void
+         */
         public function prepare_items( $data = array() ) {
             $columns = $this->get_columns();
             $hidden = array(); // Array of hidden columns.
-            $this->_column_headers = array( $columns, $hidden, array() ); // No sortable for now
+            $sortable = $this->get_sortable_columns();
+            $this->_column_headers = array( $columns, $hidden, $sortable );
+
+            // Default sort order
+            if ( empty( $_REQUEST['orderby'] ) ) {
+                $_REQUEST['orderby'] = 'date';
+                $_REQUEST['order']   = 'desc';
+            }
 
             if (empty($data)) {
                 // Updated sample data logic as above
@@ -101,6 +137,37 @@ if ( ! class_exists( 'Bol_Promotion_Methods_List_Table' ) ) {
                 }
             } else {
                 $this->items = $data;
+            }
+
+            // Sorting logic
+            $orderby = ( ! empty( $_REQUEST['orderby'] ) ) ? sanitize_text_field( $_REQUEST['orderby'] ) : 'date';
+            $order   = ( ! empty( $_REQUEST['order'] ) ) ? sanitize_text_field( $_REQUEST['order'] ) : 'desc';
+
+            if ( ! empty( $orderby ) ) {
+                usort( $this->items, function( $a, $b ) use ( $orderby, $order ) {
+                    $val_a = $a[ $orderby ];
+                    $val_b = $b[ $orderby ];
+
+                    if ( in_array( $orderby, ['clicks', 'impressions', 'clickThroughRate', 'earningsPerClick', 'orders', 'conversion', 'revenueInclVat', 'averageOrderValue'] ) ) {
+                        $val_a = floatval( str_replace(',', '.', preg_replace('/[^\d,.]/', '', $val_a) ) );
+                        $val_b = floatval( str_replace(',', '.', preg_replace('/[^\d,.]/', '', $val_b) ) );
+                    } elseif ( $orderby === 'date' ) {
+                        // Assuming YYYY-MM-DD format
+                        $time_a = strtotime( $val_a );
+                        $time_b = strtotime( $val_b );
+                        if ($time_a === $time_b) return 0;
+                        return ( $order === 'asc' ) ? ( $time_a < $time_b ? -1 : 1 ) : ( $time_a > $time_b ? -1 : 1 );
+                    } else {
+                        // String comparison
+                        $val_a = strtolower( (string) $val_a );
+                        $val_b = strtolower( (string) $val_b );
+                    }
+
+                    if ( $val_a == $val_b ) {
+                        return 0;
+                    }
+                    return ( $order === 'asc' ) ? ( $val_a < $val_b ? -1 : 1 ) : ( $val_a > $val_b ? -1 : 1 );
+                } );
             }
 
             // Pagination logic
@@ -130,8 +197,19 @@ if ( ! class_exists( 'Bol_Promotion_Methods_List_Table' ) ) {
         protected function column_default( $item, $column_name ) {
             switch ( $column_name ) {
                 case 'date':
-                    // Assuming date format YYYY-MM-DD from API, display as is.
-                    return esc_html( $item[ $column_name ] ); 
+                    // Assuming date format YYYY-MM-DD from API.
+                    if ( !empty($item[ $column_name ]) && is_string($item[ $column_name ]) ) {
+                        try {
+                           $date_obj = date_create($item[ $column_name ]);
+                           if ($date_obj) {
+                               return esc_html( date_format($date_obj, 'Y-m-d') );
+                           }
+                           return esc_html( $item[ $column_name ] ) . ' (Invalid Date Format)';
+                       } catch (Exception $e) {
+                           return esc_html( $item[ $column_name ] ) . ' (Error Parsing Date)';
+                       }
+                   }
+                   return 'N/A';
                 case 'clicks':
                 case 'impressions':
                 case 'orders':
@@ -140,12 +218,12 @@ if ( ! class_exists( 'Bol_Promotion_Methods_List_Table' ) ) {
                 case 'clickThroughRate':
                 case 'conversion':
                     // Format percentage values with two decimal places.
-                    return number_format_i18n( (float)$item[ $column_name ], 2 ) . '%';
+                    return number_format_i18n( (float) preg_replace('/[^\d,.]/', '', str_replace(',', '.', $item[ $column_name ]) ), 2 ) . '%';
                 case 'earningsPerClick':
                 case 'revenueInclVat':
                 case 'averageOrderValue':
                     // Format currency values.
-                    return '€' . number_format_i18n( (float)$item[ $column_name ], 2 );
+                    return '€' . number_format_i18n( (float) preg_replace('/[^\d,.]/', '', str_replace(',', '.', $item[ $column_name ]) ), 2 );
                 case 'siteName':
                 case 'frameType':
                 case 'name':


### PR DESCRIPTION
This commit introduces several enhancements to the Bol Affiliate Insights dashboard:

1.  **Table Sorting:**
    *   The Orders, Commission & Revenue, and Promotion Methods tables are now sortable by any column.
    *   Clicking a column header sorts the data. Subsequent clicks toggle between ascending and descending order.
    *   Visual indicators (arrows) show the current sort column and direction.
    *   Table headers are now bold.
    *   Default sorting for these tables is by date in descending order (newest first).

2.  **Date Formatting:**
    *   The `orderDate` in the Orders table is now formatted to display only the date (YYYY-MM-DD), removing the time component.

3.  **Website Filter:**
    *   A new "Filter data by Website" option has been added to the Settings page.
    *   You can select a specific website or "All Sites".
    *   This filter applies globally to data displayed in the Dashboard (summary metrics, chart), Orders tab, Commission & Revenue tab, and Promotion Methods tab.
    *   Filtering is performed client-side in PHP as the Bol.com API for these reports does not appear to support direct filtering by site ID.
    *   The filter selection is saved and persists across sessions.